### PR TITLE
Update Codex command router to dispatch issue-driven change requests

### DIFF
--- a/.github/workflows/codex-command-router.yml
+++ b/.github/workflows/codex-command-router.yml
@@ -5,8 +5,8 @@ on:
     types: [created]
 
 permissions:
-  contents: read
-  issues: read
+  contents: write
+  issues: write
   pull-requests: read
   actions: write
 
@@ -43,23 +43,60 @@ jobs:
         env:
           BODY: ${{ github.event.comment.body }}
         run: |
-          if echo "$BODY" | grep -q '^/deploy prod'; then
+          if echo "$BODY" | grep -qE '^/deploy prod([[:space:]]|$)'; then
             echo "command=deploy_prod" >> "$GITHUB_OUTPUT"
-          elif echo "$BODY" | grep -q '^/change'; then
+          elif echo "$BODY" | grep -qE '^/change([[:space:]]|$)'; then
             echo "command=change" >> "$GITHUB_OUTPUT"
+
+            # Remove the command token and trim whitespace so users can run:
+            # /change <instruction>
+            change_request="$(printf '%s' "$BODY" | sed -E '1s#^/change[[:space:]]*##')"
+            {
+              echo "request<<EOF"
+              printf '%s\n' "$change_request"
+              echo "EOF"
+            } >> "$GITHUB_OUTPUT"
           else
             echo "command=none" >> "$GITHUB_OUTPUT"
           fi
 
       - name: Handle /change
         if: steps.auth.outputs.authorized == 'true' && steps.parse.outputs.command == 'change'
-        run: |
-          cat <<'MSG'
-          Placeholder for Codex integration:
-          - Parse issue comment details
-          - Call your Codex automation service
-          - Service creates branch/commit/PR
-          MSG
+        uses: actions/github-script@v7
+        with:
+          github-token: ${{ github.token }}
+          script: |
+            const issue = context.payload.issue;
+            const comment = context.payload.comment;
+            const parsedRequest = `${{ toJson(steps.parse.outputs.request) }}`;
+            const request = parsedRequest?.trim() || `${issue.title}\n\n${issue.body || ''}`;
+
+            await github.rest.repos.createDispatchEvent({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              event_type: 'codex_change_requested',
+              client_payload: {
+                issue_number: issue.number,
+                issue_title: issue.title,
+                issue_url: issue.html_url,
+                comment_id: comment.id,
+                comment_url: comment.html_url,
+                requested_by: comment.user.login,
+                request
+              }
+            });
+
+            await github.rest.issues.createComment({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: issue.number,
+              body: [
+                '✅ `/change` command accepted.',
+                '',
+                'I dispatched a `codex_change_requested` repository event with this issue context.',
+                'Make sure a downstream workflow or automation listens for that event and performs the Codex fix flow.'
+              ].join('\n')
+            });
 
       - name: Handle /deploy prod
         if: steps.auth.outputs.authorized == 'true' && steps.parse.outputs.command == 'deploy_prod'


### PR DESCRIPTION
## Summary
- upgraded `.github/workflows/codex-command-router.yml` so `/change` is no longer a placeholder path
- added parsing support for `/change <instruction>` and stored the instruction as a step output
- replaced the placeholder `/change` handler with a `github-script` step that:
  - dispatches a `codex_change_requested` `repository_dispatch` event with issue/comment metadata and request text
  - posts an acknowledgement comment back to the issue
- expanded workflow permissions from read-only to write where required for dispatching events and creating issue comments
- tightened command matching regexes for `/deploy prod` and `/change`

## Why
This makes your issue-comment command router actually usable for an issue-driven Codex automation flow, so you can create GitHub issues/comments and have downstream automation pick up actionable change requests.

## Follow-up
Create (or wire up) a downstream workflow/service that listens for the `codex_change_requested` repository dispatch event and performs the Codex fix + PR workflow.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_698bd592b9bc83228e01580f26017b19)